### PR TITLE
fix: issue where merging block elements would track changes incorrectly

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -35,6 +35,9 @@ jobs:
     
     - name: Run Playwright tests
       run: npx playwright test
+      env:
+        CI: true
+        VITE_TINYMCE_API_KEY: ${{ secrets.VITE_TINYMCE_API_KEY }}
     - uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
       with:

--- a/__tests__/playwright/block-boundaries.spec.js
+++ b/__tests__/playwright/block-boundaries.spec.js
@@ -1,0 +1,198 @@
+/**
+ * Block boundary merging issue in TinyMCE 6+ and contenteditable
+ *
+ * Problem:
+ * TinyMCE 6+ merges adjacent block elements before ICE block boundary logic executes, breaking legacy change tracking.
+ * Contenteditable context also merges blocks, but timing and DOM state differ.
+ *
+ * Solution:
+ * The fix was to introduce an event listener for the `beforeinput` event, allowing ICE to intercept and handle block merges/splits before the DOM changes occur.
+ * This ensures correct change tracking and block boundary detection in both TinyMCE 6+ and contenteditable environments.
+ *
+ * See tests below for expected behavior after Delete/Backspace merges and change tracking.
+ * 
+ * The tests are currently skipped in Firefox due to inconsistent behavior.
+ * They are also skipped in CI environments as it seems to be impossible to use the TinyMCE API key within GitHub Actions.
+ */
+
+import { test, expect } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("http://localhost:5173/");
+});
+
+test.describe.skip("Context: contenteditable", () => {
+  test("should handle block element merging correctly after pressing Delete key", async ({
+    page,
+  }, testInfo) => {
+    if (testInfo.project.name === "firefox") {
+      test.skip("Skipped in Firefox");
+    }
+
+    const editor = await page.getByTestId("editor");
+
+    await expect(editor).toBeDefined();
+
+    // First paragraph
+    const p_1 = await editor.getByText(/Lorem ipsum/);
+
+    await expect(p_1).toBeVisible();
+
+    // Set caret to the end of the first paragraph
+    await p_1.click();
+
+    await page.keyboard.press("End");
+
+    await page.keyboard.press("Delete");
+
+    // Check that the two paragraphs are merged into a single element
+    const mergedParagraph = await editor.locator("p").filter({
+      hasText:
+        /Lorem ipsum dolor sit amet, consectetur adipiscing elit\.Praesent facilisis sed nisi nec mattis\./,
+    });
+
+    await expect(mergedParagraph).toBeVisible();
+
+    const del = mergedParagraph.locator('delete, .del, [class*="del"]');
+
+    // Ensure the merged paragraph doesn't contain any delete elements
+    await expect(del).toHaveCount(0);
+
+    await page.keyboard.press("Delete");
+
+    await expect(del).toHaveCount(1);
+
+    await expect(del).toHaveText("P");
+  });
+
+  test("should handle block element merging correctly after pressing Backspace key", async ({
+    page,
+  }, testInfo) => {
+    if (testInfo.project.name === "firefox") {
+      test.skip("Skipped in Firefox");
+    }
+
+    const editor = await page.getByTestId("editor");
+
+    await expect(editor).toBeDefined();
+
+    // Second paragraph
+    const p_2 = await editor.getByText(/Praesent/);
+
+    await expect(p_2).toBeVisible();
+
+    // Set caret to the beginning of the second paragraph
+    await p_2.click();
+
+    await page.keyboard.press("Home");
+
+    await page.keyboard.press("Backspace");
+
+    // Check that the two paragraphs are merged into a single element
+    const mergedParagraph = await editor.locator("p").filter({
+      hasText:
+        /Lorem ipsum dolor sit amet, consectetur adipiscing elit\.Praesent facilisis sed nisi nec mattis\./,
+    });
+
+    await expect(mergedParagraph).toBeVisible();
+
+    const del = mergedParagraph.locator('delete, .del, [class*="del"]');
+
+    // Ensure the merged paragraph doesn't contain any delete elements
+    await expect(del).toHaveCount(0);
+
+    await page.keyboard.press("Backspace");
+
+    await expect(del).toHaveCount(1);
+
+    await expect(del).toHaveText(".");
+  });
+});
+
+test.describe("Context: TinyMCE", () => {
+  test("should handle block element merging correctly after pressing Delete key", async ({
+    page,
+  }, testInfo) => {
+    if (testInfo.project.name === "firefox") {
+      test.skip("Skipped in Firefox");
+    }
+
+    const editor = await page.frameLocator("iFrame");
+
+    await expect(editor).toBeDefined();
+
+    // First paragraph
+    const p_1 = await editor.getByText(/Lorem ipsum/);
+
+    await expect(p_1).toBeVisible();
+
+    // Set caret to the end of the first paragraph
+    await p_1.click();
+
+    await page.keyboard.press("End");
+
+    await page.keyboard.press("Delete");
+
+    // Check that the two paragraphs are merged into a single element
+    const mergedParagraph = await editor.locator("p").filter({
+      hasText:
+        /Lorem ipsum dolor sit amet, consectetur adipiscing elit\.Praesent facilisis sed nisi nec mattis\./,
+    });
+
+    await expect(mergedParagraph).toBeVisible();
+
+    const del = mergedParagraph.locator('delete, .del, [class*="del"]');
+
+    // Ensure the merged paragraph doesn't contain any delete elements
+    await expect(del).toHaveCount(0);
+
+    await page.keyboard.press("Delete");
+
+    await expect(del).toHaveCount(1);
+
+    await expect(del).toHaveText("P");
+  });
+
+  test("should handle block element merging correctly after pressing Backspace key", async ({
+    page,
+  }, testInfo) => {
+    if (testInfo.project.name === "firefox") {
+      test.skip("Skipped in Firefox");
+    }
+
+    const editor = await page.frameLocator("iFrame");
+
+    await expect(editor).toBeDefined();
+
+    // Second paragraph
+    const p_2 = await editor.getByText(/Praesent/);
+
+    await expect(p_2).toBeVisible();
+
+    // Set caret to the beginning of the second paragraph
+    await p_2.click();
+
+    await page.keyboard.press("Home");
+
+    await page.keyboard.press("Backspace");
+
+    // Check that the two paragraphs are merged into a single element
+    const mergedParagraph = await editor.locator("p").filter({
+      hasText:
+        /Lorem ipsum dolor sit amet, consectetur adipiscing elit\.Praesent facilisis sed nisi nec mattis\./,
+    });
+
+    await expect(mergedParagraph).toBeVisible();
+
+    const del = mergedParagraph.locator('delete, .del, [class*="del"]');
+
+    // Ensure the merged paragraph doesn't contain any delete elements
+    await expect(del).toHaveCount(0);
+
+    await page.keyboard.press("Backspace");
+
+    await expect(del).toHaveCount(1);
+
+    await expect(del).toHaveText(".");
+  });
+});

--- a/demo/index.html
+++ b/demo/index.html
@@ -36,7 +36,10 @@
           <div class="control">
             <strong>Set User:</strong>
             <select onchange="setUser(this)">
-              <option data-userid="1" data-username="Smitty Werbenjägermanjensen">
+              <option
+                data-userid="1"
+                data-username="Smitty Werbenjägermanjensen"
+              >
                 Smitty Werbenjägermanjensen
               </option>
               <option data-userid="22" data-username="Chuck Noblet">
@@ -113,304 +116,12 @@
 
           <div id="content">
             <div id="text-wrapper">
-              <div id="textbody">
-                <p>
-                  <strong
-                    >Among the Wealthiest 1 Percent, Many Variations</strong
-                  ><br />By SHAILA DEWAN and ROBERT GEBELOFF
-                </p>
-
-                <p>
-                  <span
-                    class="del cts-1"
-                    data-cid="2"
-                    data-userid="33"
-                    data-username="Jerri Blank"
-                    data-time="1326764311895"
-                    title="Deleted by Jerri Blank - 01/16/2012 8:38pm"
-                    >Brooklyn</span
-                  ><span
-                    class="ins cts-1"
-                    data-cid="3"
-                    data-userid="33"
-                    data-username="Jerri Blank"
-                    data-time="1326764319303"
-                    title="Inserted by Jerri Blank - 01/16/2012 8:38pm"
-                    >Kings Point</span
-                  >, N.Y. &mdash; Adam Katz is happy to talk to reporters when
-                  he is promoting his business, a charter flight company based
-                  on Long Island called Talon Air.
-                </p>
-
-                <ul>
-                  <li>
-                    <a
-                      href="http://www.nytimes.com/packages/html/newsgraphics/2012/0115-one-percent-occupations/index.html?ref=business"
-                      >The Top 1%</a
-                    >
-                  </li>
-                  <li>
-                    <a
-                      href="http://www.nytimes.com/interactive/2012/01/15/business/one-percent-map.html?ref=business"
-                      >What Percent Are You?</a
-                    >
-                  </li>
-                </ul>
-
-                <p>
-                  But when the subject was his position as one of America's top
-                  earners, he
-                  <span
-                    class="del cts-1"
-                    data-cid="23"
-                    data-userid="33"
-                    data-username="Jerri Blank"
-                    data-time="1326765043953"
-                    title="Deleted by Jerri Blank - 01/16/2012 8:50pm"
-                    >hesitated</span
-                  ><span
-                    class="ins cts-1"
-                    data-cid="24"
-                    data-userid="33"
-                    data-username="Jerri Blank"
-                    data-time="1326765049283"
-                    title="Inserted by Jerri Blank - 01/16/2012 8:50pm"
-                    >balked</span
-                  >. Seated at a desk fashioned from a jet fuel cell<span
-                    title="Inserted by Smitty Werbenjägermanjensen - 01/16/2012 8:42pm"
-                    data-time="1326764560331"
-                    data-username="Smitty Werbenjägermanjensen"
-                    data-userid="1"
-                    data-cid="20"
-                    class="ins cts-3"
-                    >, wearing a button-down shirt with the company logo,</span
-                  >
-                  he considered the public relations benefits and found them
-                  lacking: "It's not very popular to be in the 1 percent these
-                  days, is it?"
-                </p>
-
-                <p>
-                  <img
-                    src="http://graphics8.nytimes.com/images/2012/01/15/business/ONEPERCENT/ONEPERCENT-popup.jpg"
-                    width="540"
-                  />
-                </p>
-
-                <p>
-                  <span
-                    class="ins cts-2"
-                    data-cid="14"
-                    data-userid="22"
-                    data-username="Chuck Noblet"
-                    data-time="1326764402035"
-                    title="Inserted by Chuck Noblet - 01/16/2012 8:40pm"
-                    >A few months ago, Mr. Katz was just a successful
-                    businessman with
-                    <span
-                      class="del cts-3"
-                      data-cid="15"
-                      data-userid="1"
-                      data-username="Smitty Werbenjägermanjensen"
-                      data-time="1326764492624"
-                      title="Deleted by Smitty Werbenjägermanjensen - 01/16/2012 8:41pm"
-                      >four</span
-                    ><span
-                      class="ins cts-3"
-                      data-cid="16"
-                      data-userid="1"
-                      data-username="Smitty Werbenjägermanjensen"
-                      data-time="1326764495239"
-                      title="Inserted by Smitty Werbenjägermanjensen - 01/16/2012 8:41pm"
-                      >five</span
-                    >
-                    children, an $8 million home, a family real estate company
-                    in Manhattan and his passion, 10-year-old Talon Air.</span
-                  >
-                </p>
-
-                <p>
-                  Now, the colossal gap between the very rich and everyone else
-                  <span
-                    title="Inserted by Smitty Werbenjägermanjensen - 01/16/2012 8:46pm"
-                    data-time="1326764809499"
-                    data-username="Smitty Werbenjägermanjensen"
-                    data-userid="1"
-                    data-cid="22"
-                    class="ins cts-3"
-                    >&mdash; the 1 percent versus the 99 percent &mdash; </span
-                  >has become a rallying point in this election season. As
-                  President Obama positions himself as a defender of the middle
-                  class, and Mitt Romney, the wealthiest of the Republican
-                  presidential candidates, decries such talk as "the bitter
-                  politics of envy," Mr. Katz has found himself on the wrong end
-                  of a new paradigm.
-                </p>
-                <p>
-                  <span
-                    class="ins cts-1"
-                    data-cid="30"
-                    data-userid="33"
-                    data-username="Jerri Blank"
-                    data-time="1326765098946"
-                    title="Inserted by Jerri Blank - 01/16/2012 8:51pm"
-                    >As a member of the 1 percent, he is part of a club whose
-                    name conjures images of Wall Street bosses who are
-                    chauffeured from manse to Manhattan and fat cats who have
-                    armies of lobbyists at the ready.</span
-                  >
-                </p>
-                <p>
-                  But in reality it is a far larger and more varied group, one
-                  that includes podiatrists and actuaries, executives and
-                  entrepreneurs, the self-made and the silver spoon set. They
-                  are clustered not just in New York and Los Angeles, but also
-                  in Denver and Dallas. The range of wealth in the 1 percent is
-                  vast &mdash; from households that bring in $380,000 a year,
-                  according to census data, up to billionaires like Warren E.
-                  Buffett and Bill Gates.
-                </p>
-                <p>
-                  The top 1 percent of earners in a given year receives
-                  <a
-                    title="Related data from the Tax Policy Center."
-                    href="http://www.taxpolicycenter.org/numbers/displayatab.cfm?DocID=2972"
-                    >just under a fifth</a
-                  >
-                  of the country's pretax income,
-                  <a
-                    title="A Congressional Budget Office report."
-                    href="http://www.cbo.gov/publications/collections/tax/2010/pre-tax_income_shares.pdf"
-                    >about double their share</a
-                  >
-                  30 years ago. They pay just over a fourth of all federal
-                  taxes, according to the Tax Policy Center. In 2007, they
-                  accounted for about 30 percent of philanthropic giving,
-                  according to Federal Reserve data. They received 22 percent of
-                  their income from capital gains, compared with 2 percent for
-                  everybody else.
-                </p>
-                <p>
-                  <span
-                    class="ins cts-3"
-                    data-cid="21"
-                    data-userid="1"
-                    data-username="Smitty Werbenjägermanjensen"
-                    data-time="1326764626633"
-                    title="Inserted by Smitty Werbenjägermanjensen - 01/16/2012 8:43pm"
-                    >Still, they are not necessarily the idle rich. Mr. Katz,
-                    who sometimes commutes by amphibious plane and sometimes
-                    carries luggage for Talon Air passengers, likes to say he
-                    works "26/9."</span
-                  >
-                </p>
-                <p>
-                  Most 1 percenters were born with socioeconomic advantages,
-                  which helps explain why the 1 percent is more likely than
-                  other Americans to have jobs, according to census data. They
-                  work longer hours, being three times more likely than the 99
-                  percent to work more than 50 hours a week, and are more likely
-                  to be self-employed. Married 1 percenters are just as likely
-                  as other couples to have two incomes, but men are the big
-                  breadwinners, earning 75 percent of the money, compared with
-                  64 percent of the income in other households.
-                </p>
-                <p>
-                  Though many of the wealthy lean toward the Republican Party,
-                  in interviews, 1 percenters expressed a broad range of views
-                  on how to fix the economy. They think that President Obama is
-                  ruining it, or that Republicans in Congress have gone off the
-                  deep end. They favor a flat tax, or they believe the rich
-                  should pay a higher marginal rate. Some cheered on Occupy Wall
-                  Street, saying it was about time, while others wished the
-                  protesters would just get a job or take a bath. Still others
-                  were philosophical &mdash; perhaps because they could afford
-                  to be &mdash; viewing the
-                  <a
-                    href="http://topics.nytimes.com/top/reference/timestopics/subjects/r/recession_and_depression/index.html?inline=nyt-classifier"
-                    title="More articles about the recession."
-                    class="meta-classifier"
-                    >recession</a
-                  >
-                  as something that would pass, like so many previous ups and
-                  downs.
-                </p>
-                <p>
-                  <span
-                    class="ins cts-2"
-                    data-cid="31"
-                    data-userid="22"
-                    data-username="Chuck Noblet"
-                    data-time="1326765165952"
-                    title="Inserted by Chuck Noblet - 01/16/2012 8:52pm"
-                    >Of the 1 percenters interviewed for this article, almost
-                    all &amp;mdash; conservatives and liberals alike &amp;mdash;
-                    said the wealthy could and should shoulder more of the
-                    country's financial burden, and almost all said they viewed
-                    the current system as unfair. But they may prefer facing
-                    cuts to their own benefits like &lt;a
-                    href="http://topics.nytimes.com/top/reference/timestopics/subjects/s/social_security_us/index.html?inline=nyt-classifier"
-                    title="More articles about Social Security."
-                    class="meta-classifier"&gt;Social Security&lt;/a&gt; than
-                    paying more taxes. In &lt;a title="The survey, by the
-                    Russell Sage Foundation."
-                    href="http://www.russellsage.org/blog/r-mascarenhas/wealthiest-1-percent-and-common-good"&gt;one
-                    survey&lt;/a&gt; of wealthy Chicago families, almost twice
-                    as many respondents said they would cut government spending
-                    as those who said they would cut spending and raise
-                    revenue.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span
-                  >
-                </p>
-                <p>
-                  Even those who said the deck was stacked in their favor did
-                  not appreciate anti-rich rhetoric.
-                </p>
-                <p>
-                  "I don't mind paying a little bit more in taxes. I don't mind
-                  putting money to programs that help the poor," said Anthony J.
-                  Bonomo of Manhasset, N.Y., who runs a medical malpractice
-                  insurance company and is a Republican. But, he said, he did
-                  mind taking a hit for the country's woes. "If those people
-                  could camp out in that park all day, why aren't they out
-                  looking for a job? Why are they blaming others?"
-                </p>
-                <p>
-                  To many, 99 vs. 1 was an artificial distinction that
-                  overlooked hard work and moral character. "It shouldn't be
-                  relevant," said Mr. Katz , who said he both creates job and
-                  contributes to charitable causes. "I'm not hurting anyone. I'm
-                  helping a lot of people."
-                </p>
-                <p><strong> The Enclave</strong></p>
-                <p>
-                  The placid sliver of Long Island that F. Scott Fitzgerald
-                  immortalized in "The Great Gatsby" as West Egg and East Egg
-                  seems almost to have shrugged off the recession.
-                </p>
-                <p>
-                  A stretch of northwest Nassau County that includes Great Neck,
-                  Manhasset and Port Washington, this area has the country's
-                  highest concentration of 1 percenters, and one of the lowest
-                  unemployment rates in the state. Houses in Port Washington are
-                  worth only 10 percent less than they were at their peak,
-                  according to the
-                  <a
-                    href="http://topics.nytimes.com/top/reference/timestopics/subjects/s/standard_poors_caseshiller_home_price_index/index.html?inline=nyt-classifier"
-                    title="More articles about the Case-Shiller Home Price Index."
-                    class="meta-classifier"
-                    >Standard &amp; Poor's Case-Shiller Home Price Index</a
-                  >, a far smaller decline than in the rest of the country.
-                  Yearly sales at the Americana Manhasset, the upscale granite
-                  and glass shopping center, have already exceeded their
-                  prerecession high. Even in down times, the 1 percent has
-                  <a
-                    title="Tables 1 and 2 in a related study (PDF). "
-                    href="http://www.treasury.gov/resource-center/tax-policy/Documents/incomemobilitystudy03-08revise.pdf"
-                    >staying power</a
-                  >, being far more likely than any other group to stay where
-                  they are rather than slip to lower rungs of the economic
-                  ladder.
-                </p>
+              <div id="textbody" data-testid="editor">
+                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                <p>Praesent facilisis sed nisi nec mattis.</p>
+                <p>Aliquam nulla turpis, lobortis a gravida nec, rutrum id lorem.</p>
+                <p>Ut malesuada odio condimentum scelerisque gravida.</p>
+                <p>Morbi vitae leo at dolor semper porttitor.</p>
               </div>
             </div>
           </div>
@@ -483,7 +194,10 @@
           <div class="control">
             <strong>Set User:</strong>
             <select onchange="setUserMCE(this)">
-              <option data-userid="1" data-username="Smitty Werbenjägermanjensen">
+              <option
+                data-userid="1"
+                data-username="Smitty Werbenjägermanjensen"
+              >
                 Smitty Werbenjägermanjensen
               </option>
               <option data-userid="22" data-username="Chuck Noblet">
@@ -497,9 +211,12 @@
           <div id="content">
             <div id="tinymce-wrapper">
               <textarea id="tinymce" style="width: 100%">
-						<p><span class="del cts-1" data-cid="2" data-userid="33" data-username="Jerri Blank" data-time="1326764311895" title="Deleted by Jerri Blank - 01/16/2012 8:38pm">Brooklyn</span><span class="ins cts-1" data-cid="3" data-userid="33" data-username="Jerri Blank" data-time="1326764319303" title="Inserted by Jerri Blank - 01/16/2012 8:38pm">Kings Point</span>, N.Y. &mdash; Adam Katz is happy to talk to reporters when he is promoting his business, a charter flight company based on Long Island called Talon Air.</p><p>But when the subject was his position as one of America's top earners, he <span class="del cts-1" data-cid="23" data-userid="33" data-username="Jerri Blank" data-time="1326765043953" title="Deleted by Jerri Blank - 01/16/2012 8:50pm">hesitated</span><span class="ins cts-1" data-cid="24" data-userid="33" data-username="Jerri Blank" data-time="1326765049283" title="Inserted by Jerri Blank - 01/16/2012 8:50pm">balked</span>. Seated at a desk fashioned from a jet fuel cell<span title="Inserted by Smitty Werbenjägermanjensen - 01/16/2012 8:42pm" data-time="1326764560331" data-username="Smitty Werbenjägermanjensen" data-userid="1" data-cid="20" class="ins cts-3">, wearing a button-down shirt with the company logo,</span> he considered the public relations benefits and found them lacking: "It's not very popular to be in the 1 percent these days, is it?"</p><p><span class="ins cts-2" data-cid="14" data-userid="22" data-username="Chuck Noblet" data-time="1326764402035" title="Inserted by Chuck Noblet - 01/16/2012 8:40pm">A few months ago, Mr. Katz was just a successful businessman with <span class="del cts-3" data-cid="15" data-userid="1" data-username="Smitty Werbenjägermanjensen" data-time="1326764492624" title="Deleted by Smitty Werbenjägermanjensen - 01/16/2012 8:41pm">four</span><span class="ins cts-3" data-cid="16" data-userid="1" data-username="Smitty Werbenjägermanjensen" data-time="1326764495239" title="Inserted by Smitty Werbenjägermanjensen - 01/16/2012 8:41pm">five</span> children, an $8 million home, a family real estate company in Manhattan and his passion, 10-year-old Talon Air.</span></p><p>Now, the colossal gap between the very rich and everyone else <span title="Inserted by Smitty Werbenjägermanjensen - 01/16/2012 8:46pm" data-time="1326764809499" data-username="Smitty Werbenjägermanjensen" data-userid="1" data-cid="22" class="ins cts-3">&mdash; the 1 percent versus the 99 percent &mdash; </span>has become a rallying point in this election season. As President Obama positions himself as a defender of the middle class, and Mitt Romney, the wealthiest of the Republican presidential candidates, decries such talk as "the bitter politics of envy," Mr. Katz has found himself on the wrong end of a new paradigm.</p><p><span class="ins cts-1" data-cid="30" data-userid="33" data-username="Jerri Blank" data-time="1326765098946" title="Inserted by Jerri Blank - 01/16/2012 8:51pm">As a member of the 1 percent, he is part of a club whose name conjures images of Wall Street bosses who are chauffeured from manse to Manhattan and fat cats who have armies of lobbyists at the ready.</span></p> <p>But in reality it is a far larger and more varied group, one that includes podiatrists and actuaries, executives and entrepreneurs, the self-made and the silver spoon set. They are clustered not just in New York and Los Angeles, but also in Denver and Dallas. The range of wealth in the 1 percent is vast &mdash; from households that bring in $380,000 a year, according to census data, up to billionaires like Warren E. Buffett and Bill Gates.</p><p>The top 1 percent of earners in a given year receives <a title="Related data from the Tax Policy Center." href="http://www.taxpolicycenter.org/numbers/displayatab.cfm?DocID=2972">just under a fifth</a> of the country's pretax income, <a title="A Congressional Budget Office report." href="http://www.cbo.gov/publications/collections/tax/2010/pre-tax_income_shares.pdf">about double their share</a> 30 years ago. They pay just over a fourth of all federal taxes, according to the Tax Policy Center. In 2007, they accounted for about 30 percent of philanthropic giving, according to Federal Reserve data. They received 22 percent of their income from capital gains, compared with 2 percent for everybody else.</p><p><span class="ins cts-3" data-cid="21" data-userid="1" data-username="Smitty Werbenjägermanjensen" data-time="1326764626633" title="Inserted by Smitty Werbenjägermanjensen - 01/16/2012 8:43pm">Still, they are not necessarily the idle rich. Mr. Katz, who sometimes commutes by amphibious plane and sometimes carries luggage for Talon Air passengers, likes to say he works "26/9."</span></p> <p>Most 1 percenters were born with socioeconomic advantages, which helps explain why the 1 percent is more likely than other Americans to have jobs, according to census data. They work longer hours, being three times more likely than the 99 percent to work more than 50 hours a week, and are more likely to be self-employed. Married 1 percenters are just as likely as other couples to have two incomes, but men are the big breadwinners, earning 75 percent of the money, compared with 64 percent of the income in other households.</p><p>Though many of the wealthy lean toward the Republican Party, in interviews, 1 percenters expressed a broad range of views on how to fix the economy. They think that President Obama is ruining it, or that Republicans in Congress have gone off the deep end. They favor a flat tax, or they believe the rich should pay a higher marginal rate. Some cheered on Occupy Wall Street, saying it was about time, while others wished the protesters would just get a job or take a bath. Still others were philosophical &mdash; perhaps because they could afford to be &mdash; viewing the <a href="http://topics.nytimes.com/top/reference/timestopics/subjects/r/recession_and_depression/index.html?inline=nyt-classifier" title="More articles about the recession." class="meta-classifier">recession</a> as something that would pass, like so many previous ups and downs.</p><p><span class="ins cts-2" data-cid="31" data-userid="22" data-username="Chuck Noblet" data-time="1326765165952" title="Inserted by Chuck Noblet - 01/16/2012 8:52pm">Of the 1 percenters interviewed for this article, almost all &amp;mdash; conservatives and liberals alike &amp;mdash; said the wealthy could and should shoulder more of the country's financial burden, and almost all said they viewed the current system as unfair. But they may prefer facing cuts to their own benefits like &lt;a href="http://topics.nytimes.com/top/reference/timestopics/subjects/s/social_security_us/index.html?inline=nyt-classifier" title="More articles about Social Security." class="meta-classifier"&gt;Social Security&lt;/a&gt; than paying more taxes. In &lt;a title="The survey, by the Russell Sage Foundation." href="http://www.russellsage.org/blog/r-mascarenhas/wealthiest-1-percent-and-common-good"&gt;one survey&lt;/a&gt; of wealthy Chicago families, almost twice as many respondents said they would cut government spending as those who said they would cut spending and raise revenue.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></p><p>Even those who said the deck was stacked in their favor did not appreciate anti-rich rhetoric.</p><p>"I don't mind paying a little bit more in taxes. I don't mind putting money to programs that help the poor," said Anthony J. Bonomo of Manhasset, N.Y., who runs a medical malpractice insurance company and is a Republican. But, he said, he did mind taking a hit for the country's woes. "If those people could camp out in that park all day, why aren't they out looking for a job? Why are they blaming others?"</p><p>To many, 99 vs. 1 was an artificial distinction that overlooked hard work and moral character. "It shouldn't be relevant," said Mr. Katz , who said he both creates job and contributes to charitable causes. "I'm not hurting anyone. I'm helping a lot of people."</p><p><strong> The Enclave</strong></p><p>The placid sliver of Long Island that F. Scott Fitzgerald immortalized in "The Great Gatsby" as West Egg and East Egg seems almost to have shrugged off the recession.</p><p>A stretch of northwest Nassau County that includes Great Neck, Manhasset and Port Washington, this area has the country's highest concentration of 1 percenters, and one of the lowest unemployment rates in the state. Houses in Port Washington are worth only 10 percent less than they were at their peak, according to the <a href="http://topics.nytimes.com/top/reference/timestopics/subjects/s/standard_poors_caseshiller_home_price_index/index.html?inline=nyt-classifier" title="More articles about the Case-Shiller Home Price Index." class="meta-classifier">Standard &amp; Poor's Case-Shiller Home Price Index</a>, a far smaller decline than in the rest of the country. Yearly sales at the Americana Manhasset, the upscale granite and glass shopping center, have already exceeded their prerecession high. Even in down times, the 1 percent has <a title="Tables 1 and 2 in a related study (PDF). " href="http://www.treasury.gov/resource-center/tax-policy/Documents/incomemobilitystudy03-08revise.pdf">staying power</a>, being far more likely than any other group to stay where they are rather than slip to lower rungs of the economic ladder.</p>
-					</textarea
-              >
+                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                <p>Praesent facilisis sed nisi nec mattis.</p>
+                <p>Aliquam nulla turpis, lobortis a gravida nec, rutrum id lorem.</p>
+                <p>Ut malesuada odio condimentum scelerisque gravida.</p>
+                <p>Morbi vitae leo at dolor semper porttitor.</p>
+              </textarea>
             </div>
           </div>
         </div>

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { defineConfig, devices } from '@playwright/test';
+import { defineConfig, devices } from "@playwright/test";
 
 /**
  * Read environment variables from file.
@@ -13,7 +13,7 @@ import { defineConfig, devices } from '@playwright/test';
  * @see https://playwright.dev/docs/test-configuration
  */
 export default defineConfig({
-  testDir: './__tests__',
+  testDir: "./__tests__",
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
@@ -23,31 +23,31 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: "line",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    // baseURL: 'http://localhost:3000',
+    baseURL: "http://localhost:5173",
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
+    trace: "on-first-retry",
   },
 
   /* Configure projects for major browsers */
   projects: [
     {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
     },
 
     {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
     },
 
     {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
+      name: "webkit",
+      use: { ...devices["Desktop Safari"] },
     },
 
     /* Test against mobile viewports. */
@@ -71,11 +71,12 @@ export default defineConfig({
     // },
   ],
 
-  /* Run your local dev server before starting the tests */
-  // webServer: {
-  //   command: 'npm start',
-  //   url: 'http://localhost:3000',
-  //   reuseExistingServer: !process.env.CI,
-  // },
+  /* Run the local dev server before starting the tests */
+  webServer: {
+    command: "npm run dev",
+    port: 5173,
+    // url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 15 * 1000,
+  },
 });
-

--- a/src/dom.js
+++ b/src/dom.js
@@ -10,7 +10,11 @@
 const dom = {};
 
 /** @constant {number} */
-dom.DOM_VK_DELETE = 8;
+dom.DOM_VK_DELETE = 8; // Backspace
+/** @constant {string} */
+dom.DOM_EVENT_DELETE_FWD = "deleteContentForward";
+/** @constant {string} */
+dom.DOM_EVENT_DELETE_BWD = "deleteContentBackward";
 /** @constant {number} */
 dom.DOM_VK_LEFT = 37;
 /** @constant {number} */

--- a/src/tinymce/plugins/ice/plugin.js
+++ b/src/tinymce/plugins/ice/plugin.js
@@ -269,9 +269,11 @@
       // Make the changeEditor available for other plugins
       editor.iceChangeEditor = changeEditor;
 
-      ["mousedown", "keyup", "keydown", "keypress"].forEach((eventType) => {
-        editor.on(eventType, (e) => changeEditor.handleEvent(e));
-      });
+      ["mousedown", "keyup", "keydown", "keypress", "beforeinput"].forEach(
+        (eventType) => {
+          editor.on(eventType, (e) => changeEditor.handleEvent(e));
+        },
+      );
 
       setTimeout(() => config.afterInit.call(config), 10);
     });


### PR DESCRIPTION
Starting from TinyMCE version 6, there was an issue which would cause changes to be tracked incorrectly. When merging two block elements, the first character of the second block element would be marked as a change. This was not the case within the context of normal `contenteditable` elements. This fix makes sure the behaviour is restored as it originally was, now supporting TinyMCE version 6 and up.