### PR TITLE
fix: context toolbar floating outside viewport

### DIFF
--- a/src/tinymce/plugins/ice/plugin.js
+++ b/src/tinymce/plugins/ice/plugin.js
@@ -206,6 +206,16 @@
               return false;
             }
 
+            // Ensure the node is an insert or delete tag
+            if (
+              ![config.insertTag, config.deleteTag].includes(
+                node.tagName.toLowerCase(),
+              )
+            ) {
+              return false;
+            }
+
+            // Ensure the editor body is available
             const body = editor.getBody();
             if (!body) {
               return false;
@@ -214,7 +224,11 @@
             // Check if tracking is enabled and changes are visible
             const isTrackingEnabled =
               changeEditor?.isTracking ?? config.isTracking;
-            const changesVisible = !editor.dom.hasClass(body, "CT-hide");
+            const changesVisible = !body.classList.contains("CT-hide");
+
+            if (!isTrackingEnabled || !changesVisible) {
+              return false;
+            }
 
             // Check if node or any parent has change tracking classes
             const hasChangeClass =
@@ -222,14 +236,14 @@
               node.classList.contains(config.insertClass) ||
               !!isInsideChangeTag(node);
 
-            return isTrackingEnabled && changesVisible && hasChangeClass;
+            return hasChangeClass;
           } catch (error) {
             console.error("Error in context toolbar predicate:", error);
             return false;
           }
         },
         items: "ice_accept ice_reject",
-        position: "node",
+        position: "selection",
         scope: "node",
       });
     }


### PR DESCRIPTION
When using a combination of `inline: true` and `ui_mode: 'split'`, the context toolbar could attach itself outside of the editors' container. This is most likely an issue with TinyMCE. As a simple solution to this, the `position` property for the `addContextToolbar()` function has been changed to 'selection'. Also added some basic improvements to the `predicate` logic.